### PR TITLE
Solving normalisation problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Installation/nnAudio/Untitled.ipynb
 Installation/nnAudio/Untitled-Copy1.ipynb
 Installation/nnAudio/Orthogonal.ipynb
 
+.idea
 Debug/
 performance_test/
 speed_test/

--- a/Installation/nnAudio/Spectrogram.py
+++ b/Installation/nnAudio/Spectrogram.py
@@ -1264,16 +1264,16 @@ class CQT1992v2(torch.nn.Module):
             print("Creating CQT kernels ...", end='\r')
 
         start = time()
-        cqt_kernels, self.kernel_width, lenghts = create_cqt_kernels(Q,
-                                                                     sr,
-                                                                     fmin,
-                                                                     n_bins,
-                                                                     bins_per_octave,
-                                                                     norm,
-                                                                     window,
-                                                                     fmax)
+        cqt_kernels, self.kernel_width, lenghts, freqs = create_cqt_kernels(Q,
+                                                                            sr,
+                                                                            fmin,
+                                                                            n_bins,
+                                                                            bins_per_octave,
+                                                                            norm,
+                                                                            window,
+                                                                            fmax)
         self.register_buffer('lenghts', lenghts)
-        
+        self.frequencies = freqs
         
         cqt_kernels_real = torch.tensor(cqt_kernels.real).unsqueeze(1)
         cqt_kernels_imag = torch.tensor(cqt_kernels.imag).unsqueeze(1)

--- a/Installation/nnAudio/Spectrogram.py
+++ b/Installation/nnAudio/Spectrogram.py
@@ -1203,9 +1203,11 @@ class CQT1992v2(torch.nn.Module):
         Normalization for the CQT kernels. ``1`` means L1 normalization, and ``2`` means L2 normalization.
         Default is ``1``, which is same as the normalization used in librosa.
 
-    window : str
-        The windowing function for CQT. It uses ``scipy.signal.get_window``, please refer to
-        scipy documentation for possible windowing functions. The default value is 'hann'.
+    window : string, float, or tuple
+        The windowing function for CQT. If it is a string, It uses ``scipy.signal.get_window``. If it is a
+        tuple, only the gaussian window wanrantees constant Q factor. Gaussian window should be given as a
+        tuple ('gaussian', att) where att is the attenuation in the border given in dB.
+        Please refer to scipy documentation for possible windowing functions. The default value is 'hann'.
 
     center : bool
         Putting the CQT keneral at the center of the time-step or not. If ``False``, the time index is

--- a/Installation/nnAudio/Spectrogram.py
+++ b/Installation/nnAudio/Spectrogram.py
@@ -1199,6 +1199,14 @@ class CQT1992v2(torch.nn.Module):
     bins_per_octave : int
         Number of bins per octave. Default is 12.
 
+    filter_scale : float > 0
+        Filter scale factor. Values of filter_scale smaller than 1 can be used to improve the time resolution at the
+        cost of degrading the frequency resolution. Important to note is that setting for example filter_scale = 0.5 and
+        bins_per_octave = 48 leads to exactly the same time-frequency resolution trade-off as setting filter_scale = 1
+        and bins_per_octave = 24, but the former contains twice more frequency bins per octave. In this sense, values
+        filter_scale < 1 can be seen to implement oversampling of the frequency axis, analogously to the use of zero
+        padding when calculating the DFT.
+
     norm : int
         Normalization for the CQT kernels. ``1`` means L1 normalization, and ``2`` means L2 normalization.
         Default is ``1``, which is same as the normalization used in librosa.
@@ -1222,7 +1230,7 @@ class CQT1992v2(torch.nn.Module):
         will also be caluclated and the CQT kernels will be updated during model training.
         Default value is ``False``.
 
-     output_format : str
+    output_format : str
         Determine the return type.
         ``Magnitude`` will return the magnitude of the STFT result, shape = ``(num_samples, freq_bins,time_steps)``;
         ``Complex`` will return the STFT result in complex number, shape = ``(num_samples, freq_bins,time_steps, 2)``;
@@ -1246,7 +1254,7 @@ class CQT1992v2(torch.nn.Module):
     """
 
     def __init__(self, sr=22050, hop_length=512, fmin=32.70, fmax=None, n_bins=84,
-                 bins_per_octave=12, norm=1, window='hann', center=True, pad_mode='reflect',
+                 bins_per_octave=12, filter_scale=1, norm=1, window='hann', center=True, pad_mode='reflect',
                  trainable=False, output_format='Magnitude', verbose=True):
 
         super().__init__()
@@ -1258,7 +1266,7 @@ class CQT1992v2(torch.nn.Module):
         self.output_format = output_format
 
         # creating kernels for CQT
-        Q = 1/(2**(1/bins_per_octave)-1)
+        Q = float(filter_scale)/(2**(1/bins_per_octave)-1)
 
         if verbose==True:
             print("Creating CQT kernels ...", end='\r')
@@ -1291,7 +1299,7 @@ class CQT1992v2(torch.nn.Module):
             print("CQT kernels created, time used = {:.4f} seconds".format(time()-start))
 
 
-    def forward(self,x, output_format=None):
+    def forward(self,x, output_format=None, normalization_type='librosa'):
         """
         Convert a batch of waveforms to CQT spectrograms.
         
@@ -1303,6 +1311,18 @@ class CQT1992v2(torch.nn.Module):
             2. ``(num_audio, len_audio)``\n
             3. ``(num_audio, 1, len_audio)``
             It will be automatically broadcast to the right shape
+
+        normalization_type : str
+            Type of the normalisation. The possible options are: \n
+            'librosa' : the output fits the librosa one \n
+            'convolutional' : the output conserves the convolutional inequalities of the wavelet transform:\n
+            for all p ϵ [1, inf] \n
+                - || CQT ||_p <= || f ||_p || g ||_1 \n
+                - || CQT ||_p <= || f ||_1 || g ||_p \n
+                - || CQT ||_2 = || f ||_2 || g ||_2 \n
+            'wrap' : wraps positive and negative frequencies into positive frequencies. This means that the CQT of a
+            sinus (or a cosinus) with a constant amplitude equal to 1 will have the value 1 in the bin corresponding to
+            its frequency.
         """
         output_format = output_format or self.output_format
         
@@ -1316,8 +1336,19 @@ class CQT1992v2(torch.nn.Module):
             x = padding(x)
 
         # CQT
-        CQT_real = conv1d(x, self.cqt_kernels_real, stride=self.hop_length) * 2  # cumulate positive and negative frequencies into one
-        CQT_imag = -conv1d(x, self.cqt_kernels_imag, stride=self.hop_length) * 2  # cumulate positive and negative frequencies into one
+        CQT_real = conv1d(x, self.cqt_kernels_real, stride=self.hop_length)
+        CQT_imag = -conv1d(x, self.cqt_kernels_imag, stride=self.hop_length)
+
+        if normalization_type == 'librosa':
+            CQT_real *= torch.sqrt(self.lenghts.view(-1, 1))
+            CQT_imag *= torch.sqrt(self.lenghts.view(-1, 1))
+        elif normalization_type == 'convolutional':
+            pass
+        elif normalization_type == 'wrap':
+            CQT_real *= 2
+            CQT_imag *= 2
+        else:
+            raise ValueError("The normalization_type %r is not part of our current options." % normalization_type)
 
         if output_format=='Magnitude':
             if self.trainable==False:
@@ -1428,7 +1459,7 @@ class CQT2010v2(torch.nn.Module):
         will also be caluclated and the CQT kernels will be updated during model training.
         Default value is ``False``
 
-     output_format : str
+    output_format : str
         Determine the return type.
         'Magnitude' will return the magnitude of the STFT result, shape = ``(num_samples, freq_bins, time_steps)``;
         'Complex' will return the STFT result in complex number, shape = ``(num_samples, freq_bins, time_steps, 2)``;

--- a/Installation/nnAudio/Spectrogram.py
+++ b/Installation/nnAudio/Spectrogram.py
@@ -1249,7 +1249,6 @@ class CQT1992v2(torch.nn.Module):
 
         super().__init__()
 
-        # norm arg is not functioning
         self.trainable = trainable
         self.hop_length = hop_length
         self.center = center
@@ -1315,10 +1314,8 @@ class CQT1992v2(torch.nn.Module):
             x = padding(x)
 
         # CQT
-        CQT_real = conv1d(x, self.cqt_kernels_real, stride=self.hop_length) * \
-                    torch.sqrt(self.lenghts.view(-1,1))
-        CQT_imag = -conv1d(x, self.cqt_kernels_imag, stride=self.hop_length) * \
-                    torch.sqrt(self.lenghts.view(-1,1))
+        CQT_real = conv1d(x, self.cqt_kernels_real, stride=self.hop_length) * 2  # cumulate positive and negative frequencies into one
+        CQT_imag = -conv1d(x, self.cqt_kernels_imag, stride=self.hop_length) * 2  # cumulate positive and negative frequencies into one
 
         if output_format=='Magnitude':
             if self.trainable==False:

--- a/Installation/nnAudio/utils.py
+++ b/Installation/nnAudio/utils.py
@@ -312,8 +312,6 @@ def create_cqt_kernels(Q, fs, fmin, n_bins=84, bins_per_octave=12, norm=1,
     Automatically create CQT kernels in time domain
     """
 
-    # norm arg is not functioning
-
     fftLen = 2**nextpow2(np.ceil(Q * fs / fmin))
     # minWin = 2**nextpow2(np.ceil(Q * fs / fmax))
 

--- a/Installation/nnAudio/utils.py
+++ b/Installation/nnAudio/utils.py
@@ -354,7 +354,7 @@ def create_cqt_kernels(Q, fs, fmin, n_bins=84, bins_per_octave=12, norm=1,
         # specKernel[k, :] = fft(tempKernel[k])
 
     # return specKernel[:,:fftLen//2+1], fftLen, torch.tensor(lenghts).float()
-    return tempKernel, fftLen, torch.tensor(lengths).float(), freqs
+    return tempKernel, fftLen, torch.tensor(lengths).float()
 
 
 def get_window_dispatch(window, N, fftbins=True):

--- a/Installation/nnAudio/utils.py
+++ b/Installation/nnAudio/utils.py
@@ -334,10 +334,10 @@ def create_cqt_kernels(Q, fs, fmin, n_bins=84, bins_per_octave=12, norm=1,
     tempKernel = np.zeros((int(n_bins), int(fftLen)), dtype=np.complex64)
     specKernel = np.zeros((int(n_bins), int(fftLen)), dtype=np.complex64)
 
+    lengths = np.ceil(Q * fs / freqs)
     for k in range(0, int(n_bins)):
         freq = freqs[k]
         l = np.ceil(Q * fs / freq)
-        lenghts = np.ceil(Q * fs / freqs)
 
         # Centering the kernels
         if l%2==1: # pad more zeros on RHS
@@ -345,7 +345,7 @@ def create_cqt_kernels(Q, fs, fmin, n_bins=84, bins_per_octave=12, norm=1,
         else:
             start = int(np.ceil(fftLen / 2.0 - l / 2.0))
 
-        sig = get_window(window,int(l), fftbins=True)*np.exp(np.r_[-l//2:l//2]*1j*2*np.pi*freq/fs)/l
+        sig = get_window_dispatch(window,int(l), fftbins=True)*np.exp(np.r_[-l//2:l//2]*1j*2*np.pi*freq/fs)/l
 
         if norm: # Normalizing the filter # Trying to normalize like librosa
             tempKernel[k, start:start + int(l)] = sig/np.linalg.norm(sig, norm)
@@ -354,7 +354,23 @@ def create_cqt_kernels(Q, fs, fmin, n_bins=84, bins_per_octave=12, norm=1,
         # specKernel[k, :] = fft(tempKernel[k])
 
     # return specKernel[:,:fftLen//2+1], fftLen, torch.tensor(lenghts).float()
-    return tempKernel, fftLen, torch.tensor(lenghts).float()
+    return tempKernel, fftLen, torch.tensor(lengths).float(), freqs
+
+
+def get_window_dispatch(window, N, fftbins=True):
+    if isinstance(window, str):
+        return get_window(window, N, fftbins=fftbins)
+    elif isinstance(window, tuple):
+        if window[0] == 'gaussian':
+            assert window[1] >= 0
+            sigma = np.floor(- N / 2 / np.sqrt(- 2 * np.log(10**(- window[1] / 20))))
+            return get_window(('gaussian', sigma), N, fftbins=fftbins)
+        else:
+            Warning("Tuple windows may have undesired behaviour regarding Q factor")
+    elif isinstance(window, float):
+        Warning("You are using Kaiser window with beta factor " + str(window) + ". Correct behaviour not checked.")
+    else:
+        raise Exception("The function get_window from scipy only supports strings, tuples and floats.")
 
 
 

--- a/Installation/nnAudio/utils.py
+++ b/Installation/nnAudio/utils.py
@@ -354,7 +354,7 @@ def create_cqt_kernels(Q, fs, fmin, n_bins=84, bins_per_octave=12, norm=1,
         # specKernel[k, :] = fft(tempKernel[k])
 
     # return specKernel[:,:fftLen//2+1], fftLen, torch.tensor(lenghts).float()
-    return tempKernel, fftLen, torch.tensor(lengths).float()
+    return tempKernel, fftLen, torch.tensor(lengths).float(), freqs
 
 
 def get_window_dispatch(window, N, fftbins=True):


### PR DESCRIPTION
I solved a normalisation problem in the CQT:
The essential inequality of convolution is that for all p in [1, \infty] you have
|| f * g ||_p  <=  || f ||_p · || g ||_1  ( and, because of the commutativity of the convolution, you also have || f * g ||_p = || g * f ||_p  <=  || f ||_1 · || g ||_p )
Since CQT is convolution based, we shall keep this inequality.
However, even if in the code there was indeed a normalisation of the kernels, after, during the convolution, there was another scaling factor (torch.sqrt(self.lenghts.view(-1,1))) dependent on the length of the window. I think this is not correct.
I added another scaling factor of 2, instead: the idea is that CQT only cares about positive frequencies so a sinus of amplitude 1 will have 0.5 in the bin of its frequency. It will be nice to conserve the equality (i.e.: having 1 in its bin frequency) so I added the scaling factor 2. This is, in a sense like combining positive and negative frequencies' contribution.
I hope this will be useful.   
