### PR TITLE
fix: nan value in CFP when gamma == 0

### DIFF
--- a/Installation/nnAudio/Spectrogram.py
+++ b/Installation/nnAudio/Spectrogram.py
@@ -2281,7 +2281,7 @@ class Combined_Frequency_Periodicity(nn.Module):
             X[:, :, -cutoff:] = 0
             X = X.pow(g)
         else: # when g=0, it converges to log
-            X = torch.log(X)
+            X = torch.log(X.relu())
             X[:, :, :cutoff] = 0
             X[:, :, -cutoff:] = 0
         return X   

--- a/Installation/nnAudio/Spectrogram.py
+++ b/Installation/nnAudio/Spectrogram.py
@@ -2470,7 +2470,7 @@ class CFP(nn.Module):
             X[:, :, -cutoff:] = 0
             X = X.pow(g)
         else: # when g=0, it converges to log
-            X = torch.log(X)
+            X = torch.log(X.relu())
             X[:, :, :cutoff] = 0
             X[:, :, -cutoff:] = 0
         return X   


### PR DESCRIPTION
I think a `relu()` is missing.