### PR TITLE
Numpy 1.20 update

### DIFF
--- a/Installation/nnAudio/features/cfp.py
+++ b/Installation/nnAudio/features/cfp.py
@@ -205,7 +205,7 @@ class Combined_Frequency_Periodicity(nn.Module):
                 break
 
         Nest = len(central_freq)
-        freq_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.float)
+        freq_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.double)
 
         # Calculating the freq_band_transformation
         for i in range(1, Nest - 1):
@@ -227,7 +227,7 @@ class Combined_Frequency_Periodicity(nn.Module):
 
         # Calculating the quef_band_transformation
         f = 1 / q  # divide by 0, do I need to fix this?
-        quef_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.float)
+        quef_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.double)
         for i in range(1, Nest - 1):
             for j in range(
                 int(round(fs / central_freq[i + 1])),
@@ -442,7 +442,7 @@ class CFP(nn.Module):
                 break
 
         Nest = len(central_freq)
-        freq_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.float)
+        freq_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.double)
 
         # Calculating the freq_band_transformation
         for i in range(1, Nest - 1):
@@ -464,7 +464,7 @@ class CFP(nn.Module):
 
         # Calculating the quef_band_transformation
         f = 1 / q  # divide by 0, do I need to fix this?
-        quef_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.float)
+        quef_band_transformation = np.zeros((Nest - 1, len(f)), dtype=np.double)
         for i in range(1, Nest - 1):
             for j in range(
                 int(round(fs / central_freq[i + 1])),

--- a/Installation/nnAudio/features/cqt.py
+++ b/Installation/nnAudio/features/cqt.py
@@ -404,7 +404,7 @@ class CQT2010(nn.Module):
         )
 
         # This is for the normalization in the end
-        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.float(bins_per_octave))
+        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.double(bins_per_octave))
         self.frequencies = freqs
 
         lenghts = np.ceil(Q * sr / freqs)
@@ -1033,7 +1033,7 @@ class CQT2010v2(nn.Module):
         # The freqs returned by create_cqt_kernels cannot be used
         # Since that returns only the top octave bins
         # We need the information for all freq bin
-        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.float(bins_per_octave))
+        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.double(bins_per_octave))
         self.frequencies = freqs
 
         lenghts = np.ceil(Q * sr / freqs)

--- a/Installation/nnAudio/features/vqt.py
+++ b/Installation/nnAudio/features/vqt.py
@@ -105,7 +105,7 @@ class VQT(torch.nn.Module):
         # Since that returns only the top octave bins
         # We need the information for all freq bin
         alpha = 2.0 ** (1.0 / bins_per_octave) - 1.0
-        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.float(bins_per_octave))
+        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.double(bins_per_octave))
         self.frequencies = freqs
         lenghts = np.ceil(Q * sr / (freqs + gamma / alpha))
         

--- a/Installation/nnAudio/librosa_functions.py
+++ b/Installation/nnAudio/librosa_functions.py
@@ -924,7 +924,7 @@ def normalize(S, norm=np.inf, axis=0, threshold=None, fill=None):
         raise ParameterError("Input must be finite")
 
     # All norms only depend on magnitude, let's do that first
-    mag = np.abs(S).astype(np.float)
+    mag = np.abs(S).astype(np.double)
 
     # For max/min norms, filling with 1 works
     fill_norm = 1

--- a/Installation/nnAudio/utils.py
+++ b/Installation/nnAudio/utils.py
@@ -420,17 +420,17 @@ def create_cqt_kernels(
         n_bins = np.ceil(
             bins_per_octave * np.log2(fmax / fmin)
         )  # Calculate the number of bins
-        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.float(bins_per_octave))
+        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.double(bins_per_octave))
 
     elif (fmax == None) and (n_bins != None):
-        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.float(bins_per_octave))
+        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.double(bins_per_octave))
 
     else:
         warnings.warn("If fmax is given, n_bins will be ignored", SyntaxWarning)
         n_bins = np.ceil(
             bins_per_octave * np.log2(fmax / fmin)
         )  # Calculate the number of bins
-        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.float(bins_per_octave))
+        freqs = fmin * 2.0 ** (np.r_[0:n_bins] / np.double(bins_per_octave))
 
     if np.max(freqs) > fs / 2 and topbin_check == True:
         raise ValueError(

--- a/Installation/setup.py
+++ b/Installation/setup.py
@@ -38,7 +38,9 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "scipy",
+        "scipy>=1.2.0",
+        "numpy>=1.14.5",
+        "torch>=1.6.0",
     ],
     extras_require={"tests": ["pytest", "librosa"]},
 )

--- a/README.md
+++ b/README.md
@@ -64,14 +64,11 @@ K. W. Cheuk, H. Anderson, K. Agres and D. Herremans, "nnAudio: An on-the-Fly GPU
 ## Call for Contributions
 nnAudio is a fast-growing package. With the increasing number of feature requests, we welcome anyone who is familiar with digital signal processing and neural network to contribute to nnAudio. The current list of pending features includes:
 1. Invertible Constant Q Transform (CQT)
-1. CQT with filter scale factor (see issue [#54](/../../issues/54))
-1. Speed and Performance improvements for Griffin-Lim (see issue [#41](/../../issues/41))
-1. Data Augmentation (see issue [#49](/../../issues/49))
+
 
 (Quick tips for unit test: `cd` inside Installation folder, then type `pytest`. You need at least 1931 MiB GPU memory to pass all the unit tests)
 
 Alternatively, you may also contribute by:
-   1. Refactoring the code structure (Now all functions are within the same file, but with the increasing number of features, I think we need to break it down into smaller modules)
    1. Making a better demonstration code or tutorial
 
 


### PR DESCRIPTION
Hi! [Numpy 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations) deprecates the use of `np.float`in favor of `np.double`, and depending on the Numpy version it can actually throw an error. 

I also deleted the improvement requests from the `README.md` that have been already solved :D 

At `setup.py`  there are also now some versions required for the mandatory packages required.