### PR TITLE
Ensure padding kwarg to torch Module/function is a tuple of ints

### DIFF
--- a/Installation/nnAudio/features/vqt.py
+++ b/Installation/nnAudio/features/vqt.py
@@ -172,12 +172,11 @@ class VQT(torch.nn.Module):
             else:
                 x_down = x
 
+            pad_length = int(getattr(self, 'cqt_kernels_real_{}'.format(i)).shape[-1] // 2)
             if self.pad_mode == 'constant':
-                my_padding = nn.ConstantPad1d(getattr(self,
-                                                      'cqt_kernels_real_{}'.format(i)).shape[-1] // 2, 0)
+                my_padding = nn.ConstantPad1d((pad_length, pad_length), 0)
             elif self.pad_mode == 'reflect':
-                my_padding= nn.ReflectionPad1d(getattr(self,
-                                                       'cqt_kernels_real_{}'.format(i)).shape[-1] // 2)
+                my_padding = nn.ReflectionPad1d((pad_length, pad_length))
 
             cur_vqt = get_cqt_complex(x_down,
                                       getattr(self, 'cqt_kernels_real_{}'.format(i)),

--- a/Installation/nnAudio/utils.py
+++ b/Installation/nnAudio/utils.py
@@ -95,7 +95,8 @@ def downsampling_by_n(x, filterKernel, n):
     >>> x_down = downsampling_by_n(x, filterKernel)
     """
 
-    x = conv1d(x, filterKernel, stride=n, padding=(filterKernel.shape[-1] - 1) // 2)
+    padding = int((filterKernel.shape[-1] - 1) // 2)
+    x = conv1d(x, filterKernel, stride=(n,), padding=(padding,))
     return x
 
 
@@ -120,8 +121,7 @@ def downsampling_by_2(x, filterKernel):
     >>> x_down = downsampling_by_2(x, filterKernel)
     """
 
-    x = conv1d(x, filterKernel, stride=2, padding=(filterKernel.shape[-1] - 1) // 2)
-    return x
+    return downsampling_by_n(x, filterKernel, 2)
 
 
 ## Basic tools for computation ##


### PR DESCRIPTION
When computing the VQT using `jit.trace`, errors occurred because of the integer padding arguments both to torch's `conv1d` function and the padding Modules. The present PR ensures the padding argument is a tuple, which fixes the errors.

Fixes https://github.com/KinWaiCheuk/nnAudio/issues/120